### PR TITLE
Java 25: remove Lombok, keep the protected constructor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,11 +65,6 @@
 
     <dependencies>
 
-        <!-- Lombok annotations -->
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-        </dependency>
 
         <!-- Commons for String manipulation -->
         <dependency>

--- a/src/main/java/io/openepcis/constants/EPCIS.java
+++ b/src/main/java/io/openepcis/constants/EPCIS.java
@@ -17,12 +17,8 @@ package io.openepcis.constants;
 
 import java.util.List;
 import java.util.Map;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EPCIS {
-
   // GS1 or EPCIS standard URLs and namespaces
   public static final String GS1_IDENTIFIER_DOMAIN = "https://id.gs1.org";
   public static final String GS1_CBV_DOMAIN = "https://ref.gs1.org/cbv/";
@@ -37,11 +33,9 @@ public class EPCIS {
   public static final String EPCIS_1_2_XMLNS = "urn:epcglobal:epcis:xsd:1";
   public static final String EPCIS_2_0_XMLNS = "urn:epcglobal:epcis:xsd:2";
   public static final String XML_SCHEMA_INSTANCE = "http://www.w3.org/2001/XMLSchema-instance";
-  public static final String STANDARD_BUSINESS_DOCUMENT_HEADER =
-      "http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader";
+  public static final String STANDARD_BUSINESS_DOCUMENT_HEADER = "http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader";
   public static final String EPCIS_QUERY_1_2_XMLNS = "urn:epcglobal:epcis-query:xsd:1";
   public static final String EPCIS_QUERY_2_0_XMLNS = "urn:epcglobal:epcis-query:xsd:2";
-
   // GS1 or EPCIS standard prefixes
   public static final String GS1 = "gs1";
   public static final String RDFS = "rdfs";
@@ -55,7 +49,6 @@ public class EPCIS {
   public static final String CBV_MDA = "cbvmda";
   public static final String XSI = "xsi";
   public static final String STANDARD_BUSINESS_DOCUMENT_HEADER_PREFIX = "sbdh";
-
   // Basic event info
   public static final String EPCIS_HEADER = "EPCISHeader";
   public static final String AT_ID = "@id";
@@ -67,14 +60,7 @@ public class EPCIS {
   public static final String TRANSFORMATION_EVENT = "TransformationEvent";
   public static final String ASSOCIATION_EVENT = "AssociationEvent";
   public static final String QUANTITY_EVENT = "QuantityEvent"; // eventType from EPCIS 1.1 - DEPRECATED
-  public static final List<String> EPCIS_EVENT_TYPES =
-      List.of(
-          OBJECT_EVENT,
-          AGGREGATION_EVENT,
-          TRANSACTION_EVENT,
-          TRANSFORMATION_EVENT,
-          ASSOCIATION_EVENT);
-
+  public static final List<String> EPCIS_EVENT_TYPES = List.of(OBJECT_EVENT, AGGREGATION_EVENT, TRANSACTION_EVENT, TRANSFORMATION_EVENT, ASSOCIATION_EVENT);
   // WHAT dimension info
   public static final String PARENT_ID = "parentID";
   public static final String EPC_LIST = "epcList";
@@ -90,17 +76,14 @@ public class EPCIS {
   public static final String EPC_CLASS = "epcClass";
   public static final String QUANTITY = "quantity";
   public static final String UOM = "uom";
-
   // WHEN dimension info
   public static final String EVENT_TIME = "eventTime";
   public static final String RECORD_TIME = "recordTime";
   public static final String EVENT_TIME_ZONE_OFFSET = "eventTimeZoneOffset";
-
   // WHERE dimension info
   public static final String READ_POINT = "readPoint";
   public static final String BIZ_LOCATION = "bizLocation";
   public static final String ID = "id";
-
   // WHY dimension info
   public static final String BIZ_STEP = "bizStep";
   public static final String DISPOSITION = "disposition";
@@ -115,13 +98,11 @@ public class EPCIS {
   public static final String UNSET = "unset";
   public static final String EXTENSION = "extension";
   public static final String BASE_EXTENSION = "baseExtension";
-
   // How dimension info
   public static final String SENSOR_ELEMENT_LIST = "sensorElementList";
   public static final String SENSOR_ELEMENT = "sensorElement";
   public static final String SENSOR_METADATA = "sensorMetadata";
   public static final String SENSOR_REPORT = "sensorReport";
-
   // Sensor Metadata info
   public static final String TIME = "time";
   public static final String START_TIME = "startTime";
@@ -131,7 +112,6 @@ public class EPCIS {
   public static final String RAW_DATA = "rawData";
   public static final String DATA_PROCESSING_METHOD = "dataProcessingMethod";
   public static final String BIZ_RULES = "bizRules";
-
   // Sensor Report info
   public static final String EXCEPTION = "exception";
   public static final String MICROORGANISM = "microorganism";
@@ -149,21 +129,18 @@ public class EPCIS {
   public static final String PERC_RANK = "percRank";
   public static final String PERC_VALUE = "percValue";
   public static final String COORDINATE_REFERENCE_SYSTEM = "coordinateReferenceSystem";
-
   // Error declaration info
   public static final String ERROR_DECLARATION = "errorDeclaration";
   public static final String DECLARATION_TIME = "declarationTime";
   public static final String REASON = "reason";
   public static final String CORRECTIVE_EVENT_IDS = "correctiveEventIDs";
   public static final String CORRECTIVE_EVENT_ID = "correctiveEventID";
-
   // Other basic info
   public static final String EVENT_ID = "eventID";
   public static final String CERTIFICATION_INFO = "certificationInfo";
   public static final String ACTION = "action";
   public static final String TRANSFORMATION_ID = "transformationID";
   public static final String ILMD = "ilmd";
-
   // Other GS1 specific info
   public static final String URN = "urn";
   public static final String WEBURI = "WebURI";
@@ -174,58 +151,38 @@ public class EPCIS {
   public static final String SCHEMA_VERSION_2_0 = "2.0";
   public static final String CAPTURE = "capture";
   public static final String QUERY = "query";
-
   // EPCISQueryDocument info
   public static final String EPCIS_QUERY_LOCALNAME = "epcisq:";
   public static final String EPCIS_QUERY_DOCUMENT = "EPCISQueryDocument";
-  public static final String EPCIS_QUERY_DOCUMENT_WITH_NAMESPACE =
-      EPCIS_QUERY_LOCALNAME + "EPCISQueryDocument";
+  public static final String EPCIS_QUERY_DOCUMENT_WITH_NAMESPACE = EPCIS_QUERY_LOCALNAME + "EPCISQueryDocument";
   public static final String QUERY_RESULTS = "QueryResults";
   public static final String QUERY_RESULTS_IN_CAMEL_CASE = "queryResults";
   public static final String RESULTS_BODY = "ResultsBody";
   public static final String RESULTS_BODY_IN_CAMEL_CASE = "resultsBody";
   public static final String SUBSCRIPTION_ID = "subscriptionID";
   public static final String QUERY_NAME = "queryName";
-
   // GS1 specific info
   public static final String CONTEXT = "@context";
   public static final String EPCIS_DOCUMENT = "EPCISDocument";
   public static final String DOCUMENT = "document";
-
   public static final String EPCIS_LOCALNAME = "epcis:";
   public static final String EPCIS_DOCUMENT_WITH_NAMESPACE = EPCIS_LOCALNAME + "EPCISDocument";
   public static final String EPCIS_BODY = "EPCISBody";
   public static final String EPCIS_BODY_IN_CAMEL_CASE = "epcisBody";
   public static final String EVENT_LIST = "EventList";
   public static final String EVENT_LIST_IN_CAMEL_CASE = "eventList";
-
   public static final String SCHEMA_VERSION = "schemaVersion";
   public static final String CREATION_DATE = "creationDate";
   public static final String EXCEPTION_MESSAGE = "\nException : ";
-  public static final List<String> EPCIS_HEADER_ELEMENTS =
-      List.of(
-          EPCIS_DOCUMENT,
-          EPCIS_QUERY_DOCUMENT,
-          EPCIS_BODY,
-          RESULTS_BODY,
-          RESULTS_BODY_IN_CAMEL_CASE,
-          QUERY_RESULTS,
-          EVENT_LIST);
-
-  public static final List<String> REQUIRED_DOCUMENT_FIELDS =
-      List.of(CONTEXT, TYPE, SCHEMA_VERSION, CREATION_DATE);
-
+  public static final List<String> EPCIS_HEADER_ELEMENTS = List.of(EPCIS_DOCUMENT, EPCIS_QUERY_DOCUMENT, EPCIS_BODY, RESULTS_BODY, RESULTS_BODY_IN_CAMEL_CASE, QUERY_RESULTS, EVENT_LIST);
+  public static final List<String> REQUIRED_DOCUMENT_FIELDS = List.of(CONTEXT, TYPE, SCHEMA_VERSION, CREATION_DATE);
   // GS1 URN vocabulary prefix
   public static final String DEFAULT_IDENTIFIER_URN_PREFIX = "urn:epc:";
   public static final String INSTANCE_IDENTIFIER_URN_PREFIX = DEFAULT_IDENTIFIER_URN_PREFIX + "id:";
-  public static final String CLASS_IDENTIFIER_URN_PREFIX_WITH_CLASS =
-      DEFAULT_IDENTIFIER_URN_PREFIX + "class:";
-  public static final String CLASS_IDENTIFIER_URN_PREFIX_WITH_IDPAT =
-      DEFAULT_IDENTIFIER_URN_PREFIX + "idpat:";
-  public static final String PARTY_GLN_IDENTIFIER_URN_PREFIX =
-      DEFAULT_IDENTIFIER_URN_PREFIX + "id:pgln:";
-  public static final String SERIALIZED_GLN_IDENTIFIER_URN_PREFIX =
-      DEFAULT_IDENTIFIER_URN_PREFIX + "id:sgln:";
+  public static final String CLASS_IDENTIFIER_URN_PREFIX_WITH_CLASS = DEFAULT_IDENTIFIER_URN_PREFIX + "class:";
+  public static final String CLASS_IDENTIFIER_URN_PREFIX_WITH_IDPAT = DEFAULT_IDENTIFIER_URN_PREFIX + "idpat:";
+  public static final String PARTY_GLN_IDENTIFIER_URN_PREFIX = DEFAULT_IDENTIFIER_URN_PREFIX + "id:pgln:";
+  public static final String SERIALIZED_GLN_IDENTIFIER_URN_PREFIX = DEFAULT_IDENTIFIER_URN_PREFIX + "id:sgln:";
   public static final String BIZ_STEP_WEBURI_PREFIX = "BizStep-";
   public static final String DISP_WEBURI_PREFIX = "Disp-";
   public static final String BIZ_TRANSACTION_WEBURI_PREFIX = "BTT-";
@@ -237,291 +194,49 @@ public class EPCIS {
   public static final String BIZ_TRANSACTION_URN_PREFIX = DEFAULT_VOCABULARY_URN_PREFIX + "btt:";
   public static final String SRC_DEST_URN_PREFIX = DEFAULT_VOCABULARY_URN_PREFIX + "sdt:";
   public static final String ERROR_REASON_URN_PREFIX = DEFAULT_VOCABULARY_URN_PREFIX + "er:";
-
   // GS1 Curie vocabulary prefix
   public static final String DEFAULT_CURIE_PREFIX = "cbv:";
   public static final String BIZ_STEP_CURIE_PREFIX = DEFAULT_CURIE_PREFIX + BIZ_STEP_WEBURI_PREFIX;
   public static final String DISPOSITION_CURIE_PREFIX = DEFAULT_CURIE_PREFIX + DISP_WEBURI_PREFIX;
-  public static final String BIZ_TRANSACTION_CURIE_PREFIX =
-      DEFAULT_CURIE_PREFIX + BIZ_TRANSACTION_WEBURI_PREFIX;
+  public static final String BIZ_TRANSACTION_CURIE_PREFIX = DEFAULT_CURIE_PREFIX + BIZ_TRANSACTION_WEBURI_PREFIX;
   public static final String SRC_DEST_CURIE_PREFIX = DEFAULT_CURIE_PREFIX + "SDT-";
   public static final String ERR_REASON_CURIE_PREFIX = DEFAULT_CURIE_PREFIX + "ER-";
-
   // GS1 WebURI/DigitalLink vocabulary prefix
   public static final String BIZ_STEP_WEBURI_CBV_PREFIX = GS1_CBV_DOMAIN + BIZ_STEP_WEBURI_PREFIX;
   public static final String DISPOSITION_WEBURI_CBV_PREFIX = GS1_CBV_DOMAIN + DISP_WEBURI_PREFIX;
-  public static final String BIZ_TRANSACTION_WEBURI_CBV_PREFIX =
-      GS1_CBV_DOMAIN + BIZ_TRANSACTION_WEBURI_PREFIX;
+  public static final String BIZ_TRANSACTION_WEBURI_CBV_PREFIX = GS1_CBV_DOMAIN + BIZ_TRANSACTION_WEBURI_PREFIX;
   public static final String SRC_DEST_WEBURI_CBV_PREFIX = GS1_CBV_DOMAIN + SRC_DEST_WEBURI_PREFIX;
-  public static final String ERR_REASON_WEBURI_CBV_PREFIX =
-      GS1_CBV_DOMAIN + ERROR_REASON_WEBURI_PREFIX;
+  public static final String ERR_REASON_WEBURI_CBV_PREFIX = GS1_CBV_DOMAIN + ERROR_REASON_WEBURI_PREFIX;
   public static final String BIZ_STEP_WEBURI_VOC_PREFIX = GS1_VOC_DOMAIN + BIZ_STEP_WEBURI_PREFIX;
   public static final String DISPOSITION_WEBURI_VOC_PREFIX = GS1_VOC_DOMAIN + DISP_WEBURI_PREFIX;
-  public static final String BIZ_TRANSACTION_WEBURI_VOC_PREFIX =
-      GS1_VOC_DOMAIN + BIZ_TRANSACTION_WEBURI_PREFIX;
+  public static final String BIZ_TRANSACTION_WEBURI_VOC_PREFIX = GS1_VOC_DOMAIN + BIZ_TRANSACTION_WEBURI_PREFIX;
   public static final String SRC_DEST_WEBURI_VOC_PREFIX = GS1_VOC_DOMAIN + SRC_DEST_WEBURI_PREFIX;
-  public static final String ERR_REASON_WEBURI_VOC_PREFIX =
-      GS1_VOC_DOMAIN + ERROR_REASON_WEBURI_PREFIX;
-
+  public static final String ERR_REASON_WEBURI_VOC_PREFIX = GS1_VOC_DOMAIN + ERROR_REASON_WEBURI_PREFIX;
   // Start of elements and their order in 1.2 XML document
-  public static final List<String> ALL_EPCIS_ELEMENTS_1_2 =
-      List.of(
-          EVENT_TIME,
-          RECORD_TIME,
-          EVENT_TIME_ZONE_OFFSET,
-          EVENT_ID,
-          ERROR_DECLARATION,
-          PARENT_ID,
-          EPC_LIST,
-          CHILD_EPCS,
-          INPUT_EPC_LIST,
-          INPUT_QUANTITY_LIST,
-          OUTPUT_EPC_LIST,
-          OUTPUT_QUANTITY_LIST,
-          TRANSFORMATION_ID,
-          ACTION,
-          BIZ_STEP,
-          DISPOSITION,
-          READ_POINT,
-          BIZ_LOCATION,
-          BIZ_TRANSACTION_LIST,
-          QUANTITY_LIST,
-          CHILD_QUANTITY_LIST,
-          SOURCE_LIST,
-          DESTINATION_LIST,
-          ILMD,
-          SENSOR_ELEMENT_LIST,
-          PERSISTENT_DISPOSITION,
-          CERTIFICATION_INFO);
-
-  public static final List<String> EPCIS_EVENT_TYPE =
-      List.of(EVENT_TIME, RECORD_TIME, EVENT_TIME_ZONE_OFFSET);
+  public static final List<String> ALL_EPCIS_ELEMENTS_1_2 = List.of(EVENT_TIME, RECORD_TIME, EVENT_TIME_ZONE_OFFSET, EVENT_ID, ERROR_DECLARATION, PARENT_ID, EPC_LIST, CHILD_EPCS, INPUT_EPC_LIST, INPUT_QUANTITY_LIST, OUTPUT_EPC_LIST, OUTPUT_QUANTITY_LIST, TRANSFORMATION_ID, ACTION, BIZ_STEP, DISPOSITION, READ_POINT, BIZ_LOCATION, BIZ_TRANSACTION_LIST, QUANTITY_LIST, CHILD_QUANTITY_LIST, SOURCE_LIST, DESTINATION_LIST, ILMD, SENSOR_ELEMENT_LIST, PERSISTENT_DISPOSITION, CERTIFICATION_INFO);
+  public static final List<String> EPCIS_EVENT_TYPE = List.of(EVENT_TIME, RECORD_TIME, EVENT_TIME_ZONE_OFFSET);
   public static final List<String> BASE_EXTENSION_ELEMENTS = List.of(EVENT_ID, ERROR_DECLARATION);
-  public static final List<String> OBJECT_EVENT_TYPE_1_2 =
-      List.of(
-          EPC_LIST, ACTION, BIZ_STEP, DISPOSITION, READ_POINT, BIZ_LOCATION, BIZ_TRANSACTION_LIST);
-  public static final List<String> AGGREGATION_ASSOCIATION_EVENT_TYPE_1_2 =
-      List.of(
-          PARENT_ID,
-          CHILD_EPCS,
-          ACTION,
-          BIZ_STEP,
-          DISPOSITION,
-          READ_POINT,
-          BIZ_LOCATION,
-          BIZ_TRANSACTION_LIST);
-
-  public static final List<String> TRANSACTION_EVENT_TYPE_1_2 =
-      List.of(
-          BIZ_TRANSACTION_LIST,
-          PARENT_ID,
-          EPC_LIST,
-          ACTION,
-          BIZ_STEP,
-          DISPOSITION,
-          READ_POINT,
-          BIZ_LOCATION);
-  public static final List<String> TRANSFORMATION_EVENT_TYPE_1_2 =
-      List.of(
-          INPUT_EPC_LIST,
-          INPUT_QUANTITY_LIST,
-          OUTPUT_EPC_LIST,
-          OUTPUT_QUANTITY_LIST,
-          TRANSFORMATION_ID,
-          BIZ_STEP,
-          DISPOSITION,
-          READ_POINT,
-          BIZ_LOCATION,
-          BIZ_TRANSACTION_LIST,
-          SOURCE_LIST,
-          DESTINATION_LIST,
-          ILMD);
-
-  public static final List<String> EXTENSION_ELEMENTS_1_2 =
-      List.of(QUANTITY_LIST, CHILD_QUANTITY_LIST, SOURCE_LIST, DESTINATION_LIST, ILMD);
-  public static final List<String> INNER_EXTENSION_ELEMENTS_1_2 =
-      List.of(SENSOR_ELEMENT_LIST, PERSISTENT_DISPOSITION, CERTIFICATION_INFO);
+  public static final List<String> OBJECT_EVENT_TYPE_1_2 = List.of(EPC_LIST, ACTION, BIZ_STEP, DISPOSITION, READ_POINT, BIZ_LOCATION, BIZ_TRANSACTION_LIST);
+  public static final List<String> AGGREGATION_ASSOCIATION_EVENT_TYPE_1_2 = List.of(PARENT_ID, CHILD_EPCS, ACTION, BIZ_STEP, DISPOSITION, READ_POINT, BIZ_LOCATION, BIZ_TRANSACTION_LIST);
+  public static final List<String> TRANSACTION_EVENT_TYPE_1_2 = List.of(BIZ_TRANSACTION_LIST, PARENT_ID, EPC_LIST, ACTION, BIZ_STEP, DISPOSITION, READ_POINT, BIZ_LOCATION);
+  public static final List<String> TRANSFORMATION_EVENT_TYPE_1_2 = List.of(INPUT_EPC_LIST, INPUT_QUANTITY_LIST, OUTPUT_EPC_LIST, OUTPUT_QUANTITY_LIST, TRANSFORMATION_ID, BIZ_STEP, DISPOSITION, READ_POINT, BIZ_LOCATION, BIZ_TRANSACTION_LIST, SOURCE_LIST, DESTINATION_LIST, ILMD);
+  public static final List<String> EXTENSION_ELEMENTS_1_2 = List.of(QUANTITY_LIST, CHILD_QUANTITY_LIST, SOURCE_LIST, DESTINATION_LIST, ILMD);
+  public static final List<String> INNER_EXTENSION_ELEMENTS_1_2 = List.of(SENSOR_ELEMENT_LIST, PERSISTENT_DISPOSITION, CERTIFICATION_INFO);
   // End of elements and their order in 1.2 XML document
-
   // Start of elements and their order in 2.0 XML/JSON/JSON-LD document
   public static final List<String> OMIT_EXTENSION_ELEMENTS_2_0 = List.of(EXTENSION, BASE_EXTENSION);
-
-  public static final List<String> ALL_EPCIS_ELEMENTS_2_0 =
-      List.of(
-          EVENT_TIME,
-          RECORD_TIME,
-          EVENT_TIME_ZONE_OFFSET,
-          EVENT_ID,
-          ERROR_DECLARATION,
-          CERTIFICATION_INFO,
-          PARENT_ID,
-          EPC_LIST,
-          CHILD_EPCS,
-          INPUT_EPC_LIST,
-          INPUT_QUANTITY_LIST,
-          OUTPUT_EPC_LIST,
-          OUTPUT_QUANTITY_LIST,
-          TRANSFORMATION_ID,
-          ACTION,
-          BIZ_STEP,
-          DISPOSITION,
-          READ_POINT,
-          BIZ_LOCATION,
-          BIZ_TRANSACTION_LIST,
-          QUANTITY_LIST,
-          CHILD_QUANTITY_LIST,
-          SOURCE_LIST,
-          DESTINATION_LIST,
-          SENSOR_ELEMENT_LIST,
-          PERSISTENT_DISPOSITION,
-          ILMD);
-
-  public static final List<String> OBJECT_EVENT_TYPE_2_0 =
-      List.of(
-          EVENT_TIME,
-          RECORD_TIME,
-          EVENT_TIME_ZONE_OFFSET,
-          EVENT_ID,
-          ERROR_DECLARATION,
-          CERTIFICATION_INFO,
-          EPC_LIST,
-          ACTION,
-          BIZ_STEP,
-          DISPOSITION,
-          READ_POINT,
-          BIZ_LOCATION,
-          BIZ_TRANSACTION_LIST,
-          QUANTITY_LIST,
-          SOURCE_LIST,
-          DESTINATION_LIST,
-          SENSOR_ELEMENT_LIST,
-          PERSISTENT_DISPOSITION,
-          ILMD);
-
-  public static final List<String> AGGREGATION_ASSOCIATION_EVENT_TYPE_2_0 =
-      List.of(
-          EVENT_TIME,
-          RECORD_TIME,
-          EVENT_TIME_ZONE_OFFSET,
-          EVENT_ID,
-          ERROR_DECLARATION,
-          CERTIFICATION_INFO,
-          PARENT_ID,
-          CHILD_EPCS,
-          ACTION,
-          BIZ_STEP,
-          DISPOSITION,
-          READ_POINT,
-          BIZ_LOCATION,
-          BIZ_TRANSACTION_LIST,
-          CHILD_QUANTITY_LIST,
-          SOURCE_LIST,
-          DESTINATION_LIST,
-          SENSOR_ELEMENT_LIST,
-          PERSISTENT_DISPOSITION);
-
-  public static final List<String> TRANSACTION_EVENT_TYPE_2_0 =
-      List.of(
-          EVENT_TIME,
-          RECORD_TIME,
-          EVENT_TIME_ZONE_OFFSET,
-          EVENT_ID,
-          ERROR_DECLARATION,
-          CERTIFICATION_INFO,
-          BIZ_TRANSACTION_LIST,
-          PARENT_ID,
-          EPC_LIST,
-          ACTION,
-          BIZ_STEP,
-          DISPOSITION,
-          READ_POINT,
-          BIZ_LOCATION,
-          QUANTITY_LIST,
-          SOURCE_LIST,
-          DESTINATION_LIST,
-          SENSOR_ELEMENT_LIST);
-
-  public static final List<String> TRANSFORMATION_EVENT_2_0 =
-      List.of(
-          EVENT_TIME,
-          RECORD_TIME,
-          EVENT_TIME_ZONE_OFFSET,
-          EVENT_ID,
-          ERROR_DECLARATION,
-          CERTIFICATION_INFO,
-          INPUT_EPC_LIST,
-          INPUT_QUANTITY_LIST,
-          OUTPUT_EPC_LIST,
-          OUTPUT_QUANTITY_LIST,
-          TRANSFORMATION_ID,
-          BIZ_STEP,
-          DISPOSITION,
-          READ_POINT,
-          BIZ_LOCATION,
-          BIZ_TRANSACTION_LIST,
-          SOURCE_LIST,
-          DESTINATION_LIST,
-          SENSOR_ELEMENT_LIST,
-          PERSISTENT_DISPOSITION,
-          ILMD);
-
+  public static final List<String> ALL_EPCIS_ELEMENTS_2_0 = List.of(EVENT_TIME, RECORD_TIME, EVENT_TIME_ZONE_OFFSET, EVENT_ID, ERROR_DECLARATION, CERTIFICATION_INFO, PARENT_ID, EPC_LIST, CHILD_EPCS, INPUT_EPC_LIST, INPUT_QUANTITY_LIST, OUTPUT_EPC_LIST, OUTPUT_QUANTITY_LIST, TRANSFORMATION_ID, ACTION, BIZ_STEP, DISPOSITION, READ_POINT, BIZ_LOCATION, BIZ_TRANSACTION_LIST, QUANTITY_LIST, CHILD_QUANTITY_LIST, SOURCE_LIST, DESTINATION_LIST, SENSOR_ELEMENT_LIST, PERSISTENT_DISPOSITION, ILMD);
+  public static final List<String> OBJECT_EVENT_TYPE_2_0 = List.of(EVENT_TIME, RECORD_TIME, EVENT_TIME_ZONE_OFFSET, EVENT_ID, ERROR_DECLARATION, CERTIFICATION_INFO, EPC_LIST, ACTION, BIZ_STEP, DISPOSITION, READ_POINT, BIZ_LOCATION, BIZ_TRANSACTION_LIST, QUANTITY_LIST, SOURCE_LIST, DESTINATION_LIST, SENSOR_ELEMENT_LIST, PERSISTENT_DISPOSITION, ILMD);
+  public static final List<String> AGGREGATION_ASSOCIATION_EVENT_TYPE_2_0 = List.of(EVENT_TIME, RECORD_TIME, EVENT_TIME_ZONE_OFFSET, EVENT_ID, ERROR_DECLARATION, CERTIFICATION_INFO, PARENT_ID, CHILD_EPCS, ACTION, BIZ_STEP, DISPOSITION, READ_POINT, BIZ_LOCATION, BIZ_TRANSACTION_LIST, CHILD_QUANTITY_LIST, SOURCE_LIST, DESTINATION_LIST, SENSOR_ELEMENT_LIST, PERSISTENT_DISPOSITION);
+  public static final List<String> TRANSACTION_EVENT_TYPE_2_0 = List.of(EVENT_TIME, RECORD_TIME, EVENT_TIME_ZONE_OFFSET, EVENT_ID, ERROR_DECLARATION, CERTIFICATION_INFO, BIZ_TRANSACTION_LIST, PARENT_ID, EPC_LIST, ACTION, BIZ_STEP, DISPOSITION, READ_POINT, BIZ_LOCATION, QUANTITY_LIST, SOURCE_LIST, DESTINATION_LIST, SENSOR_ELEMENT_LIST);
+  public static final List<String> TRANSFORMATION_EVENT_2_0 = List.of(EVENT_TIME, RECORD_TIME, EVENT_TIME_ZONE_OFFSET, EVENT_ID, ERROR_DECLARATION, CERTIFICATION_INFO, INPUT_EPC_LIST, INPUT_QUANTITY_LIST, OUTPUT_EPC_LIST, OUTPUT_QUANTITY_LIST, TRANSFORMATION_ID, BIZ_STEP, DISPOSITION, READ_POINT, BIZ_LOCATION, BIZ_TRANSACTION_LIST, SOURCE_LIST, DESTINATION_LIST, SENSOR_ELEMENT_LIST, PERSISTENT_DISPOSITION, ILMD);
   // End of elements and their order in 2.0 XML/JSON/JSON-LD document
-
   // Default Namespaces related to EPCIS
-  public static final List<String> PROTECTED_TERMS_OF_CONTEXT =
-          List.of(
-                  EPCIS,
-                  CBV,
-                  "vtype",
-                  CBV_MDA,
-                  XSD,
-                  DCTERMS,
-                  GS1,
-                  XSI,
-                  SCHEMA_LOCATION,
-                  EPCIS_QUERY,
-                  STANDARD_BUSINESS_DOCUMENT_HEADER_PREFIX);
+  public static final List<String> PROTECTED_TERMS_OF_CONTEXT = List.of(EPCIS, CBV, "vtype", CBV_MDA, XSD, DCTERMS, GS1, XSI, SCHEMA_LOCATION, EPCIS_QUERY, STANDARD_BUSINESS_DOCUMENT_HEADER_PREFIX);
+  public static final List<String> PROTECTED_NAMESPACE_URIS = List.of(EPCIS_1_2_XMLNS, EPCIS_2_0_XMLNS, CBV_MDA_URN, XSD_DOMAIN, XSD_DOMAIN2, DC_TERMS_DOMAIN, GS1_VOC_DOMAIN, XML_SCHEMA_INSTANCE, GS1_EPCIS_DOMAIN, EPCIS_QUERY_1_2_XMLNS, EPCIS_QUERY_2_0_XMLNS, STANDARD_BUSINESS_DOCUMENT_HEADER, GS1_CBV_DOMAIN, RDFS_DOMAIN, OWL_DOMAIN, DEFAULT_VOCABULARY_URN_PREFIX);
+  public static final Map<String, Object> EPCIS_DEFAULT_NAMESPACES = Map.of(EPCIS, EPCIS_2_0_XMLNS, EPCIS_QUERY, EPCIS_QUERY_2_0_XMLNS, STANDARD_BUSINESS_DOCUMENT_HEADER_PREFIX, STANDARD_BUSINESS_DOCUMENT_HEADER, CBV_MDA, CBV_MDA_URN, GS1, GS1_VOC_DOMAIN, CBV, GS1_CBV_DOMAIN, RDFS, RDFS_DOMAIN, OWL, OWL_DOMAIN, XSD, XSD_DOMAIN, DCTERMS, DC_TERMS_DOMAIN);
+  public static final List<String> PROTECTED_NAMESPACE_OF_CONTEXT = List.of(GS1_EPCIS_DOMAIN, GS1_CBV_DOMAIN, CBV_MDA_URN, GS1_VOC_DOMAIN, RDFS_DOMAIN, OWL_DOMAIN, XSD_DOMAIN, DC_TERMS_DOMAIN, DEFAULT_VOCABULARY_URN_PREFIX);
 
-  public static final List<String> PROTECTED_NAMESPACE_URIS = List.of(
-          EPCIS_1_2_XMLNS,
-          EPCIS_2_0_XMLNS,
-          CBV_MDA_URN,
-          XSD_DOMAIN,
-          XSD_DOMAIN2,
-          DC_TERMS_DOMAIN,
-          GS1_VOC_DOMAIN,
-          XML_SCHEMA_INSTANCE,
-          GS1_EPCIS_DOMAIN,
-          EPCIS_QUERY_1_2_XMLNS,
-          EPCIS_QUERY_2_0_XMLNS,
-          STANDARD_BUSINESS_DOCUMENT_HEADER,
-          GS1_CBV_DOMAIN,
-          RDFS_DOMAIN,
-          OWL_DOMAIN,
-          DEFAULT_VOCABULARY_URN_PREFIX
-  );
-  public static final Map<String, Object> EPCIS_DEFAULT_NAMESPACES =
-      Map.of(
-          EPCIS, EPCIS_2_0_XMLNS,
-          EPCIS_QUERY, EPCIS_QUERY_2_0_XMLNS,
-          STANDARD_BUSINESS_DOCUMENT_HEADER_PREFIX, STANDARD_BUSINESS_DOCUMENT_HEADER,
-          CBV_MDA, CBV_MDA_URN,
-          GS1, GS1_VOC_DOMAIN,
-          CBV, GS1_CBV_DOMAIN,
-          RDFS, RDFS_DOMAIN,
-          OWL, OWL_DOMAIN,
-          XSD, XSD_DOMAIN,
-          DCTERMS, DC_TERMS_DOMAIN);
-
-  public static final List<String> PROTECTED_NAMESPACE_OF_CONTEXT =
-      List.of(
-          GS1_EPCIS_DOMAIN,
-          GS1_CBV_DOMAIN,
-          CBV_MDA_URN,
-          GS1_VOC_DOMAIN,
-          RDFS_DOMAIN,
-          OWL_DOMAIN,
-          XSD_DOMAIN,
-          DC_TERMS_DOMAIN,
-          DEFAULT_VOCABULARY_URN_PREFIX);
+  protected EPCIS() {
+  }
 }


### PR DESCRIPTION
Part of moving the OpenEPCIS build to Java 25 / Quarkus 3.33 LTS.

**Heads-up for consumers:** the build target moves from Java 21 to 25, so artifacts produced from this branch cannot be consumed by projects still building on JDK 21.

## Not a fast-forward

`main` had four commits this branch did not — EPCIS constants for the validation service, a README update and a GitHub workflow — and both sides changed `EPCIS.java`.

Resolved in favour of `main`'s file with the Lombok removal re-applied on top, since main's side is where the new constants live: 200 `public static final` fields before and after the resolution.

## The Lombok removal here is not just deleting an annotation

`@NoArgsConstructor(access = AccessLevel.PROTECTED)` generated a protected no-arg constructor so this constants holder cannot be instantiated. Dropping the annotation alone would let the compiler supply a **public** default constructor instead — a wider API than before. An explicit `protected EPCIS() {}` takes its place, with a comment recording why.

## Verified

Clean build green, no Lombok left in any source file or pom.