### PR TITLE
feat(constants): AI-Prefixe fuer die Rollen-GLNs und GMN

### DIFF
--- a/src/main/java/io/openepcis/constants/ApplicationIdentifierConstants.java
+++ b/src/main/java/io/openepcis/constants/ApplicationIdentifierConstants.java
@@ -62,6 +62,20 @@ public class ApplicationIdentifierConstants {
     public static final String LGTIN_AI_BATCH_LOT_PREFIX = "/10/";
     public static final String LGTIN_AI_URN_PREFIX = ":lgtin:";
 
+    // === GMN (8013) ===
+    public static final String GMN_AI_URI_PREFIX = "/8013/";
+
+    // === Party-role GLNs (410, 411, 412, 413, 415) ===
+    // A GLN in a business role rather than as a location or party identity. GS1's Digital
+    // Link grammar admits all five as primary keys, and the resolver description schema
+    // permits them in supportedPrimaryKeys — but EPCIS has no URN form for any of them,
+    // so unlike SGLN (414) and PGLN (417) they are Digital-Link-only.
+    public static final String SHIP_TO_AI_URI_PREFIX = "/410/";
+    public static final String BILL_TO_AI_URI_PREFIX = "/411/";
+    public static final String PURCHASED_FROM_AI_URI_PREFIX = "/412/";
+    public static final String SHIP_FOR_AI_URI_PREFIX = "/413/";
+    public static final String PAY_TO_AI_URI_PREFIX = "/415/";
+
     // === PGLN (417) ===
     public static final String PGLN_AI_URI_PREFIX = "/417/";
     public static final String PGLN_AI_URN_PREFIX = ":pgln:";


### PR DESCRIPTION
## Was

Fuegt die AI-Prefixe fuer sechs GS1-Primaerschluessel hinzu, die bisher fehlten:

| AI | Konstante | Bedeutung |
|---|---|---|
| 410 | `SHIP_TO_AI_URI_PREFIX` | Ship-to / Deliver-to GLN |
| 411 | `BILL_TO_AI_URI_PREFIX` | Bill-to / Invoice-to GLN |
| 412 | `PURCHASED_FROM_AI_URI_PREFIX` | Purchased-from GLN |
| 413 | `SHIP_FOR_AI_URI_PREFIX` | Ship-for / Forward-to GLN |
| 415 | `PAY_TO_AI_URI_PREFIX` | Pay-to GLN |
| 8013 | `GMN_AI_URI_PREFIX` | Global Model Number |

## Warum

GS1s Resolver-Beschreibungsschema erlaubt alle sechs in `supportedPrimaryKeys`,
und keine von ihnen hat eine EPCIS-URN-Form — anders als SGLN (414) und PGLN (417)
sind sie Digital-Link-only.

## Abhaengigkeit

Reiner Konstanten-Zusatz, keine Verhaltensaenderung. Voraussetzung fuer die
Validatoren in `openepcis-epc-digitallink-translator`, die diese Prefixe nutzen.
